### PR TITLE
Stringify dicts for json and jsonb data types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='sql2csv',
-    version='1.2',
+    version='1.3',
     description='Run MySQL and PostgreSQL queries and store result in CSV',
     long_description=long_description,
     author='Gabriel Bordeaux',

--- a/src/unittest/test_sql2csv.py
+++ b/src/unittest/test_sql2csv.py
@@ -199,6 +199,15 @@ class Test(unittest.TestCase):
         assert sql2csv.strip_whitespaces(
             ['  some  ', '  thing', 'else  ']) == ['some', 'thing', 'else']
 
+    def test_stringify_items(self):
+        # No change expected
+        assert sql2csv.stringify_items(
+            (1, 2, 'a', 'b', 'c')) == (1, 2, 'a', 'b', 'c')
+
+        # Json encoding of dict is expected
+        assert sql2csv.stringify_items((1, 2, {'a': True, 'b': False, 'c': 'some string'})) == (
+            1, 2, '{"a": true, "b": false, "c": "some string"}')
+
     @patch('sys.stdin.isatty')
     def test_has_stdin_input(self, mocked):
         mocked.return_value = True


### PR DESCRIPTION
When a column has the data type `json` or `jsonb`, `sql2csv` used to return a Python `dict` instead of an expected Json-encoded string.

This PR adds a column type check to Json-encode dicts.